### PR TITLE
Append client ID to session storage artifacts

### DIFF
--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -76,13 +76,18 @@ export class AsgardeoAuthClient<T> {
      *
      * @preserve
      */
-    public constructor(store: Store, cryptoUtils: CryptoUtils) {
+    public constructor(store: Store, cryptoUtils: CryptoUtils, clientId?: string) {
         if (!AsgardeoAuthClient._instanceID) {
             AsgardeoAuthClient._instanceID = 0;
         } else {
             AsgardeoAuthClient._instanceID += 1;
         }
-        this._dataLayer = new DataLayer<T>(`instance_${ AsgardeoAuthClient._instanceID }`, store);
+
+        if (!clientId) {
+            this._dataLayer = new DataLayer<T>(`instance_${ AsgardeoAuthClient._instanceID }`, store);
+        } else {
+            this._dataLayer = new DataLayer<T>(`instance_${ AsgardeoAuthClient._instanceID }-${clientId}`, store);
+        }
         this._authenticationCore = new AuthenticationCore(this._dataLayer, cryptoUtils);
         AsgardeoAuthClient._authenticationCore = new AuthenticationCore(this._dataLayer, cryptoUtils);
     }

--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -55,8 +55,8 @@ const DefaultConfig: Partial<AuthClientConfig<unknown>> = {
  * This class provides the necessary methods needed to implement authentication.
 */
 export class AsgardeoAuthClient<T> {
-    private _dataLayer: DataLayer<T>;
-    private _authenticationCore: AuthenticationCore<T>;
+    private _dataLayer!: DataLayer<T>;
+    private _authenticationCore!: AuthenticationCore<T>;
 
     private static _instanceID: number;
     static _authenticationCore: any;
@@ -76,21 +76,7 @@ export class AsgardeoAuthClient<T> {
      *
      * @preserve
      */
-    public constructor(store: Store, cryptoUtils: CryptoUtils, clientId?: string) {
-        if (!AsgardeoAuthClient._instanceID) {
-            AsgardeoAuthClient._instanceID = 0;
-        } else {
-            AsgardeoAuthClient._instanceID += 1;
-        }
-
-        if (!clientId) {
-            this._dataLayer = new DataLayer<T>(`instance_${ AsgardeoAuthClient._instanceID }`, store);
-        } else {
-            this._dataLayer = new DataLayer<T>(`instance_${ AsgardeoAuthClient._instanceID }-${ clientId }`, store);
-        }
-        this._authenticationCore = new AuthenticationCore(this._dataLayer, cryptoUtils);
-        AsgardeoAuthClient._authenticationCore = new AuthenticationCore(this._dataLayer, cryptoUtils);
-    }
+    public constructor() {}
 
     /**
      *
@@ -111,7 +97,24 @@ export class AsgardeoAuthClient<T> {
      *
      * @preserve
      */
-    public async initialize(config: AuthClientConfig<T>): Promise<void> {
+    public async initialize(config: AuthClientConfig<T>, store: Store, cryptoUtils: CryptoUtils): Promise<void> {
+        const clientId: string = config.clientID;
+
+        if (!AsgardeoAuthClient._instanceID) {
+            AsgardeoAuthClient._instanceID = 0;
+        } else {
+            AsgardeoAuthClient._instanceID += 1;
+        }
+
+        if (!clientId) {
+            this._dataLayer = new DataLayer<T>(`instance_${ AsgardeoAuthClient._instanceID }`, store);
+        } else {
+            this._dataLayer = new DataLayer<T>(`instance_${ AsgardeoAuthClient._instanceID }-${ clientId }`, store);
+        }
+
+        this._authenticationCore = new AuthenticationCore(this._dataLayer, cryptoUtils);
+        AsgardeoAuthClient._authenticationCore = new AuthenticationCore(this._dataLayer, cryptoUtils);
+
         await this._dataLayer.setConfigData({
             ...DefaultConfig,
             ...config,

--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -86,7 +86,7 @@ export class AsgardeoAuthClient<T> {
         if (!clientId) {
             this._dataLayer = new DataLayer<T>(`instance_${ AsgardeoAuthClient._instanceID }`, store);
         } else {
-            this._dataLayer = new DataLayer<T>(`instance_${ AsgardeoAuthClient._instanceID }-${clientId}`, store);
+            this._dataLayer = new DataLayer<T>(`instance_${ AsgardeoAuthClient._instanceID }-${ clientId }`, store);
         }
         this._authenticationCore = new AuthenticationCore(this._dataLayer, cryptoUtils);
         AsgardeoAuthClient._authenticationCore = new AuthenticationCore(this._dataLayer, cryptoUtils);


### PR DESCRIPTION
## Purpose
This will append client ID of the application to the key of the objects in the session storage. This will prevent token overriding when 2 different applications are hosted on the same subdomain (Ex: `example.com/app1` and `example.com/app2`)

Under this, the session storage will look like this.
![Screenshot 2023-02-14 at 17 00 29](https://user-images.githubusercontent.com/42619922/218725264-0be7b261-76c0-4ff1-b1a8-01d9e3f142d6.png)

## Related Issue
- https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/163
