### PR TITLE
Allow instance ID to be passed in the initialize() function

### DIFF
--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -97,13 +97,22 @@ export class AsgardeoAuthClient<T> {
      *
      * @preserve
      */
-    public async initialize(config: AuthClientConfig<T>, store: Store, cryptoUtils: CryptoUtils): Promise<void> {
+    public async initialize(
+        config: AuthClientConfig<T>,
+        store: Store,
+        cryptoUtils: CryptoUtils,
+        instanceID?: number
+    ): Promise<void> {
         const clientId: string = config.clientID;
 
         if (!AsgardeoAuthClient._instanceID) {
             AsgardeoAuthClient._instanceID = 0;
         } else {
             AsgardeoAuthClient._instanceID += 1;
+        }
+
+        if (instanceID) {
+            AsgardeoAuthClient._instanceID = instanceID;
         }
 
         if (!clientId) {
@@ -141,6 +150,22 @@ export class AsgardeoAuthClient<T> {
      */
     public getDataLayer(): DataLayer<T> {
         return this._dataLayer;
+    }
+
+    /**
+     * This method returns the `instanceID` variable of the given instance.
+     *
+     * @returns - The `instanceID` number.
+     *
+     * @example
+     * ```
+     * const instanceId = auth.getInstanceID();
+     * ```
+     *
+     * @preserve
+     */
+    public getInstanceID(): number {
+        return AsgardeoAuthClient._instanceID;
     }
 
     /**


### PR DESCRIPTION
## Purpose
This will allow to sync the instance ID between SPA SDK and JS Core and will facilitate maintaining instance-wise entries in the session storage for all artifacts.
![Screenshot 2023-02-16 at 13 15 18](https://user-images.githubusercontent.com/42619922/219300240-ce0fbac4-d331-4448-a476-5f25d7e1d6e1.png)

## Related Issue
- https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/163
