### PR TITLE
Send client_id in logout request

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,10 +985,11 @@ This model has the following attributes.
 |`validateIDToken`|Optional| `boolean`|`true`|Allows you to enable/disable JWT ID token validation after obtaining the ID token.|
 |`clockTolerance`|Optional| `number`|`60`|Allows you to configure the leeway when validating the id_token.|
 |`sendCookiesInRequests`|Optional| `boolean`|`true`|Specifies if cookies should be sent in the requests.|
+|`sendIdTokenInLogoutRequest`|Optional| `boolean`|`false`|Specifies if `id_token_hint` parameter should be sent in the logout request instead of the default `client_id` parameter.|
 
 The `AuthClientConfig<T>` can be extended by passing an interface as the generic type. For example, if you want to add an attribute called `foo` to the config object, you can create an interface called `Bar` and pass that as the generic type into the `AuthClientConfig<T>` interface.
 
-```TypeScript
+```TypeScripthttps://github.com/asgardeo/asgardeo-auth-js-core/pull/236
 interface Bar {
     foo: string
 }

--- a/README.md
+++ b/README.md
@@ -989,7 +989,7 @@ This model has the following attributes.
 
 The `AuthClientConfig<T>` can be extended by passing an interface as the generic type. For example, if you want to add an attribute called `foo` to the config object, you can create an interface called `Bar` and pass that as the generic type into the `AuthClientConfig<T>` interface.
 
-```TypeScripthttps://github.com/asgardeo/asgardeo-auth-js-core/pull/236
+```TypeScript
 interface Bar {
     foo: string
 }

--- a/lib/src/core/authentication-core.ts
+++ b/lib/src/core/authentication-core.ts
@@ -546,16 +546,6 @@ export class AuthenticationCore<T> {
             );
         }
 
-        const idToken: string = (await this._dataLayer.getSessionData(userID))?.id_token;
-
-        if (!idToken || idToken.trim().length === 0) {
-            throw new AsgardeoAuthException(
-                "JS-AUTH_CORE-GSOU-NF02",
-                "ID token not found.",
-                "No ID token could be found. Either the session information is lost or you have not signed in."
-            );
-        }
-
         const callbackURL: string = configData?.signOutRedirectURL ?? configData?.signInRedirectURL;
 
         if (!callbackURL || callbackURL.trim().length === 0) {
@@ -567,9 +557,24 @@ export class AuthenticationCore<T> {
             );
         }
 
+        let parameter: string = `client_id=${ configData.clientID }`;
+
+        if (configData.sendIdTokenInLogoutRequest) {
+            const idToken: string = (await this._dataLayer.getSessionData(userID))?.id_token;
+
+            if (!idToken || idToken.trim().length === 0) {
+                throw new AsgardeoAuthException(
+                    "JS-AUTH_CORE-GSOU-NF02",
+                    "ID token not found.",
+                    "No ID token could be found. Either the session information is lost or you have not signed in."
+                );
+            }
+            parameter = `id_token_hint=${ idToken }`;
+        }
+
         const logoutCallback: string =
             `${ logoutEndpoint }?` +
-            `client_id=${ configData.clientID }` +
+            parameter +
             `&post_logout_redirect_uri=${ callbackURL }&state=` +
             SIGN_OUT_SUCCESS_PARAM;
 

--- a/lib/src/core/authentication-core.ts
+++ b/lib/src/core/authentication-core.ts
@@ -569,7 +569,7 @@ export class AuthenticationCore<T> {
 
         const logoutCallback: string =
             `${ logoutEndpoint }?` +
-            `id_token_hint=${ idToken }` +
+            `client_id=${ configData.clientID }` +
             `&post_logout_redirect_uri=${ callbackURL }&state=` +
             SIGN_OUT_SUCCESS_PARAM;
 

--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -40,6 +40,7 @@ export interface DefaultAuthClientConfig {
   *
   */
   sendCookiesInRequests?: boolean;
+  sendIdTokenInLogoutRequest?: boolean;
 }
 
 export interface WellKnownAuthClientConfig extends DefaultAuthClientConfig {


### PR DESCRIPTION
## Purpose
This PR updates the `getSignOutURL` method to send `client_id` query parameter instead of `id_token_hint` by default. This PR also introduces a new optional config `sendIdTokenInLogoutRequest`. If this is set to true, logout request will contain `id_token_hint` parameter instead of `client_id`

### Related issue
- https://github.com/wso2-enterprise/asgardeo-product/issues/19594