### PR TITLE
[IS 5.11.0] Add Functionality to Enable or Disable ID Token Issuer Validation

### DIFF
--- a/packages/oidc-js/README.md
+++ b/packages/oidc-js/README.md
@@ -229,6 +229,7 @@ This method takes a `config` object as the only argument. The attributes of the 
 |`authorizationCode` (optional)| `string`|""|When the `responseMode` is set to `from_post`, the authorization code is returned as a `POST` request. Apps can use this attribute to pass the obtained authorization code to the SDK. Since client applications can't handle `POST` requests, the application's backend should implement the logic to receive the authorization code and send it back to the SDK.|
 | `sessionState` (optional) | `string`|""| When the `responseMode` is set to `from_post`, the session state is returned as a `POST` request. Apps can use this attribute to pass the obtained session state to the SDK. Since client applications can't handle `POST` requests, the application's backend should implement the logic to receive the session state and send it back to the SDK.|
 |`validateIDToken`(optional)|`boolean`|`true`|Allows you to enable/disable JWT ID token validation after obtaining the ID token.|
+|`validateIDTokenIssuer`(optional)|`boolean`|`true`|Allows you to enable/disable JWT ID token issuer validation after obtaining the ID token (Only when JWT ID token validation is enabled).|
 |`clockTolerance`(optional)|`number`|`60`|Allows you to configure the leeway when validating the id_token.|
 
 The `initialize` hook is used to fire a callback function after initializing is successful. Check the [on()](#on) section for more information.

--- a/packages/oidc-js/README.md
+++ b/packages/oidc-js/README.md
@@ -229,7 +229,7 @@ This method takes a `config` object as the only argument. The attributes of the 
 |`authorizationCode` (optional)| `string`|""|When the `responseMode` is set to `from_post`, the authorization code is returned as a `POST` request. Apps can use this attribute to pass the obtained authorization code to the SDK. Since client applications can't handle `POST` requests, the application's backend should implement the logic to receive the authorization code and send it back to the SDK.|
 | `sessionState` (optional) | `string`|""| When the `responseMode` is set to `from_post`, the session state is returned as a `POST` request. Apps can use this attribute to pass the obtained session state to the SDK. Since client applications can't handle `POST` requests, the application's backend should implement the logic to receive the session state and send it back to the SDK.|
 |`validateIDToken`(optional)|`boolean`|`true`|Allows you to enable/disable JWT ID token validation after obtaining the ID token.|
-|`validateIDTokenIssuer`(optional)|`boolean`|`true`|Allows you to enable/disable JWT ID token issuer validation after obtaining the ID token (Only when JWT ID token validation is enabled).|
+| `validateIDTokenIssuer`(optional) | `boolean` | `true` | Allows you to enable/disable JWT ID token issuer validation after obtaining the ID token (This config is applicable only when JWT ID token validation is enabled). |
 |`clockTolerance`(optional)|`number`|`60`|Allows you to configure the leeway when validating the id_token.|
 
 The `initialize` hook is used to fire a callback function after initializing is successful. Check the [on()](#on) section for more information.

--- a/packages/oidc-js/src/client.ts
+++ b/packages/oidc-js/src/client.ts
@@ -67,7 +67,8 @@ const DefaultConfig = {
     enablePKCE: true,
     responseMode: null,
     scope: [OIDC_SCOPE],
-    validateIDToken: true
+    validateIDToken: true,
+    validateIDTokenIssuer: true
 };
 
 /**

--- a/packages/oidc-js/src/models/client.ts
+++ b/packages/oidc-js/src/models/client.ts
@@ -38,6 +38,7 @@ interface BaseConfigInterface {
     authorizationCode?: string;
     sessionState?: string;
     validateIDToken?: boolean;
+    validateIDTokenIssuer?: boolean;
     customParams?: CustomParamsInterface;
     /**
      * Allowed leeway for id_tokens (in seconds).

--- a/packages/oidc-js/src/utils/op-config.ts
+++ b/packages/oidc-js/src/utils/op-config.ts
@@ -293,8 +293,7 @@ export const initOPConfiguration = (
                 new Error(
                     "Initialized OpenID Provider configuration from default configuration." +
                         "Because failed to access wellknown endpoint: " +
-                        serverHost +
-                        SERVICE_RESOURCES.wellKnown
+                        wellKnownEndpoint
                 )
             );
         });

--- a/packages/oidc-js/src/utils/sign-in.ts
+++ b/packages/oidc-js/src/utils/sign-in.ts
@@ -230,8 +230,9 @@ export function validateIdToken(
             }
 
             // Return false if the issuer in the open id config doesn't match
-            // the issuer in the well known endpoint URL.
-            if (!issuer || issuer !== issuerFromURL) {
+            // the issuer in the well known endpoint URL when issuer validation is enabled.
+            // This is enabled by default.
+            if (requestParams.validateIDTokenIssuer && (!issuer || issuer !== issuerFromURL)) {
                 return Promise.resolve(false);
             }
 

--- a/packages/oidc-js/src/utils/sign-in.ts
+++ b/packages/oidc-js/src/utils/sign-in.ts
@@ -232,7 +232,7 @@ export function validateIdToken(
             // Return false if the issuer in the open id config doesn't match
             // the issuer in the well known endpoint URL when issuer validation is enabled.
             // This is enabled by default.
-            if (requestParams.validateIDTokenIssuer && (!issuer || issuer !== issuerFromURL)) {
+            if ((requestParams.validateIDTokenIssuer ?? true) && (!issuer || issuer !== issuerFromURL)) {
                 return Promise.resolve(false);
             }
 


### PR DESCRIPTION
## Purpose
- This PR adds a new config, `validateIDTokenIssuer`, in order to enable/ disable ID token issuer validation.

## Goals
- When the `Identity Provider Entity ID` is changed, the ID token issuer validation can be disabled if the new well-known endpoint is not configured in initialization of  `IdentityClient`.

## Approach
- A new config, `validateIDTokenIssuer`, is introduced to enable/ disable ID token issuer validation.
- The default value for `validateIDTokenIssuer` would be `true` and when initializing `IdentityClient`, the required value for `validateIDTokenIssuer` can be configured.

## Release note
- A new config, `validateIDTokenIssuer`, is introduced to enable/ disable ID token issuer validation.
- The default value for `validateIDTokenIssuer` would be `true` and when initializing `IdentityClient`, the required value for `validateIDTokenIssuer` can be configured.

## Documentation
- Readme file of the repo is updated with this PR.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related Issues
- https://github.com/wso2/product-is/issues/17956

## Test environment
- Product: `IS 5.11.0.302`
- OS: `macos Sonoma 14.0`
- Database: `default`
- JDK: `openJDK 11`
