### PR TITLE
Add Functionality Enable or Disable ID Token Issuer Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,7 @@ This model has the following attributes.
 |`endpoints`|Optional (Required to provide all endpoints, if `wellKnownEndpoint` or `baseUrl` is not provided)| `OIDCEndpoints`|[OIDC Endpoints Default Values](#oidc-endpoints)|The OIDC endpoint URLs. The SDK will try to obtain the endpoint URLS |using the `.well-known` endpoint. If this fails, the SDK will use these endpoint URLs. If this attribute is not set, then the default endpoint URLs will be |used.
 |`wellKnownEndpoint`|Optional (Required if `baseUrl` or `endpoints` is not provided)| `string`|`"/oauth2/token/.well-known/openid-configuration"`| The URL of the `.well-known` endpoint.|
 |`validateIDToken`|Optional| `boolean`|`true`|Allows you to enable/disable JWT ID token validation after obtaining the ID token.|
+|`validateIDTokenIssuer`(optional) | `boolean` | `true` | Allows you to enable/disable JWT ID token issuer validation after obtaining the ID token (This config is applicable only when JWT ID token validation is enabled). |
 |`clockTolerance`|Optional| `number`|`60`|Allows you to configure the leeway when validating the id_token.|
 |`sendCookiesInRequests`|Optional| `boolean`|`true`|Specifies if cookies should be sent in the requests.|
 |`sendIdTokenInLogoutRequest`|Optional| `boolean`|`false`|Specifies if `id_token_hint` parameter should be sent in the logout request instead of the default `client_id` parameter.|

--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -48,7 +48,8 @@ const DefaultConfig: Partial<AuthClientConfig<unknown>> = {
     responseMode: ResponseMode.query,
     scope: [ OIDC_SCOPE ],
     sendCookiesInRequests: true,
-    validateIDToken: true
+    validateIDToken: true,
+    validateIDTokenIssuer: true
 };
 
 /**

--- a/lib/src/helpers/authentication-helper.ts
+++ b/lib/src/helpers/authentication-helper.ts
@@ -223,7 +223,8 @@ export class AuthenticationHelper<T> {
             (await this._config()).clientID,
             issuer ?? "",
             this._cryptoHelper.decodeIDToken(idToken).sub,
-            (await this._config()).clockTolerance
+            (await this._config()).clockTolerance, 
+            (await this._config()).validateIDTokenIssuer ?? true
         );
     }
 

--- a/lib/src/helpers/crypto-helper.ts
+++ b/lib/src/helpers/crypto-helper.ts
@@ -97,10 +97,20 @@ export class CryptoHelper<T = any> {
         clientID: string,
         issuer: string,
         username: string,
-        clockTolerance: number | undefined
+        clockTolerance: number | undefined,
+        validateJwtIssuer: boolean | undefined
     ): Promise<boolean> {
         return this._cryptoUtils
-            .verifyJwt(idToken, jwk, SUPPORTED_SIGNATURE_ALGORITHMS, clientID, issuer, username, clockTolerance)
+            .verifyJwt(
+                idToken, 
+                jwk, 
+                SUPPORTED_SIGNATURE_ALGORITHMS, 
+                clientID, 
+                issuer, 
+                username, 
+                clockTolerance, 
+                validateJwtIssuer
+            )
             .then((response: boolean) => {
                 if (response) {
                     return Promise.resolve(true);

--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -30,6 +30,7 @@ export interface DefaultAuthClientConfig {
   responseMode?: ResponseMode;
   scope?: string[];
   validateIDToken?: boolean;
+  validateIDTokenIssuer?: boolean;
   /**
   * Allowed leeway for id_tokens (in seconds).
   */

--- a/lib/src/models/crypto.ts
+++ b/lib/src/models/crypto.ts
@@ -92,6 +92,7 @@ export interface CryptoUtils<T = any> {
         clientID: string,
         issuer: string,
         subject: string,
-        clockTolerance?: number
+        clockTolerance?: number,
+        validateJwtIssuer?: boolean
     ): Promise<boolean>;
 }


### PR DESCRIPTION
## Purpose
- This PR adds a new config, `validateIDTokenIssuer`, in order to enable/ disable ID token issuer validation.

## Goals
- When the `Identity Provider Entity ID` is changed, the ID token issuer validation can be disabled if the new issuer is not configured in initialization of  `AsgardeoAuthClient`.

## Approach
- A new config, `validateIDTokenIssuer`, is introduced to enable/ disable ID token issuer validation.
- The default value for `validateIDTokenIssuer` would be `true` and when initializing `AsgardeoAuthClient`, the required value for `validateIDTokenIssuer` can be configured.

## Release note
- A new config, `validateIDTokenIssuer`, is introduced to enable/ disable ID token issuer validation.
- The default value for `validateIDTokenIssuer` would be `true` and when initializing `AsgardeoAuthClient`, the required value for `validateIDTokenIssuer` can be configured.

## Documentation
- Readme file of the repo is updated with this PR.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related Issues
- https://github.com/wso2/product-is/issues/17956

## Test environment
- Product: `IS 7.0.0 rc1 SNAPSHOT`
- OS: `macos Sonoma 14.0`
- Database: `default`
- JDK: `openJDK 11`
