### PR TITLE
Fix client secret dropping issue from the js-core level

### DIFF
--- a/lib/src/core/authentication-core.ts
+++ b/lib/src/core/authentication-core.ts
@@ -76,6 +76,10 @@ export class AuthenticationCore<T> {
         authorizeRequestParams.set("response_type", "code");
         authorizeRequestParams.set("client_id", configData.clientID);
 
+        if (configData.clientSecret && configData.clientSecret.trim().length > 0) {
+            authorizeRequestParams.set("client_secret", configData.clientSecret);
+        }
+
         let scope: string = OIDC_SCOPE;
 
         if (configData.scope && configData.scope.length > 0) {


### PR DESCRIPTION
## Purpose

Currently, even if we pass the `client secret` along with the client id to the authorize API call, the client secret is dropped from the authorize API call in the auth-js-core level. This PR fixes the `client secret` dropping issue from the js-core level.

## Git Issue
- https://github.com/asgardeo/asgardeo-auth-js-core/issues/252