### PR TITLE
fix bug in revokeAccessToken method

### DIFF
--- a/lib/src/core/authentication-core.ts
+++ b/lib/src/core/authentication-core.ts
@@ -336,6 +336,10 @@ export class AuthenticationCore<T> {
         body.push(`token=${ (await this._dataLayer.getSessionData(userID)).access_token }`);
         body.push("token_type_hint=access_token");
 
+        if (configData.clientSecret && configData.clientSecret.trim().length > 0) {
+            body.push(`client_secret=${ configData.clientSecret }`);
+        }
+
         let response: Response;
 
         try {


### PR DESCRIPTION
### Purpose
Fixes an issue where the revokeAccessToken method does not include client_secret in the revocation request body, causing token revocation to fail for confidential clients with the error invalid_client. This change ensures the SDK supports both public and confidential clients by conditionally appending client_secret from the config if available.

### Related Issues
- fixes #262


### Related PRs
- N/A

### Checklist
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
